### PR TITLE
Add warning sentence in TI ui "Run without --medvram or --lowvram."

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -969,7 +969,7 @@ def create_ui(wrap_gradio_gpu_call):
         with gr.Row().style(equal_height=False):
             with gr.Column():
                 with gr.Group():
-                    gr.HTML(value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">wiki</a></b> for detailed explanation.</p>")
+                    gr.HTML(value="<p style='margin-bottom: 0.7em'>See <b><a href=\"https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Textual-Inversion\">wiki</a></b> for detailed explanation. Run without --medvram or --lowvram. </p>")
 
                     gr.HTML(value="<p style='margin-bottom: 0.7em'>Create a new embedding</p>")
 


### PR DESCRIPTION
Lessens user error. 